### PR TITLE
Alternative fix for Committee label clipping

### DIFF
--- a/src/components/committee/Sidebar.tsx
+++ b/src/components/committee/Sidebar.tsx
@@ -63,7 +63,7 @@ export const Sidebar = ({ committees, ...props }: Props) => {
     const isAboveMd = useBreakpointValue({ base: false, md: true });
 
     return (
-        <VStack
+        <VStack py={5}
             w={{ base: "45px", sm: "min-content", lg: "225px" }}
             spacing={0.5}
             align="stretch"


### PR DESCRIPTION
This fixes issue #8 without affecting other pages. Still temporary fix, it would be best to find a way to set the margin persistent across the default page and the committee pages. Check closed pull request #13 for more info