### PR TITLE
fix: :lipstick: change font to depend on viewport instead of fixed

### DIFF
--- a/src/components/event/Carousel.tsx
+++ b/src/components/event/Carousel.tsx
@@ -87,7 +87,7 @@ export const Carousel = ({ children, title, description, ...props }: Props) => {
                     <Spacer />
                     <Box>
                         <Heading
-                            fontSize="5xl"
+                            fontSize="6vw"
                             color="white"
                             textTransform="capitalize"
                             fontWeight="bold"
@@ -95,7 +95,11 @@ export const Carousel = ({ children, title, description, ...props }: Props) => {
                         >
                             {title}
                         </Heading>
-                        <Text color="white" fontFamily="source sans pro">
+                        <Text
+                            fontSize="2.5vw"
+                            color="white"
+                            fontFamily="source sans pro"
+                        >
                             {description}
                         </Text>
                     </Box>


### PR DESCRIPTION
Please view Issue #43 for more information this solves the issue for realistic screen sizes but stops working when screen width is less than ~200 pixels

## Big
### Before
![Screenshot 2022-05-27 at 19 51 01](https://user-images.githubusercontent.com/77754074/170764400-5b9c190a-0fb4-4a83-a278-26c2703fbe2c.png)
### After
![Screenshot 2022-05-27 at 19 49 19](https://user-images.githubusercontent.com/77754074/170764177-cb94f164-2be9-45eb-9e6c-33539a36ff79.png)

## Small
### Before
![Screenshot 2022-05-27 at 19 51 18](https://user-images.githubusercontent.com/77754074/170764445-1046391f-6814-4bbb-a701-f57db494a4f6.png)
### After
![Screenshot 2022-05-27 at 19 49 35](https://user-images.githubusercontent.com/77754074/170764218-8d49489d-80dc-4e8e-8717-2246a77f51e6.png)

_Note: The font size was arbitrarily chosen and can be enlarged and made smaller according to taste_
