### PR TITLE
Added url to event query in Blog Model

### DIFF
--- a/src/components/blog/Gallery.tsx
+++ b/src/components/blog/Gallery.tsx
@@ -109,7 +109,7 @@ export const Gallery = ({
                                 categories: item.categories,
                                 href: item?.__href ?? "#",
                                 imgurl:
-                                    item?.__media?.formats.medium.url ??
+                                    item?.__media?.url ??
                                     "/indek_template_fill.png",
                                 calendarDate: item?.__calendarDate ?? "N/A",
                                 title: item.title,

--- a/src/models/blog.ts
+++ b/src/models/blog.ts
@@ -144,6 +144,7 @@ const getEvents = async (locale: TLocale) => {
             }
             media {
               name
+              url
               formats
             }
             schedule {

--- a/src/views/Blog/Blog.tsx
+++ b/src/views/Blog/Blog.tsx
@@ -169,7 +169,7 @@ const View = ({ header, footer, feed, categories }: LayoutProps<Props>) => {
                     <LinkComponent as={Box} href={firstItem?.__href ?? "#"}>
                         <NextImage
                             src={
-                                firstItem?.__media?.formats.medium.url ??
+                                firstItem?.__media?.url ??
                                 "/indek_template_fill.png"
                             }
                             width="2048px"


### PR DESCRIPTION
This is a **proper** fix to the problem and not a temporary fix like the previous solution. I forgot to fix the url for the smaller events on the blog page. This pull request fixes the issue across the blog page. 