### PR TITLE
feat: :children_crossing: Reversed order of displayed documents

### DIFF
--- a/src/views/Document.tsx
+++ b/src/views/Document.tsx
@@ -55,7 +55,7 @@ const View = ({ data, header, footer, error }: LayoutProps<Props>) => {
                         <Empty title="No Documents found" />
                     )}
                     {documents.length > 0 &&
-                        documents.map((d, i) => (
+                        [...documents].reverse().map((d, i) => (
                             <WrapItem key={"thumbnail-" + i}>
                                 <ItemThumbnail {...d} size={sizeVariant} />
                             </WrapItem>


### PR DESCRIPTION
Reversed order of documents, now it's from latest upload to first upload which improves readability. Spread syntax was used to modify read only array and then reversed.