### PR TITLE
fix: :bug: Incorrect naming of option types between button and actual…

### DIFF
--- a/src/views/Blog/Blog.tsx
+++ b/src/views/Blog/Blog.tsx
@@ -75,7 +75,7 @@ const View = ({ header, footer, feed, categories }: LayoutProps<Props>) => {
                 ? _type.split(",").map((item: string) => item.toLowerCase())
                 : _type.toLowerCase();
         }
-        return ["event", "job", "post"];
+        return ["event", "jobs", "post"];
     }, [query]);
 
     const preselectedOptions = useCallback(
@@ -91,7 +91,7 @@ const View = ({ header, footer, feed, categories }: LayoutProps<Props>) => {
     const [options, _setOptions] = useState<SelectOption[]>(
         [
             { label: t("article.event"), value: "Event" },
-            { label: t("article.job"), value: "Job" },
+            { label: t("article.job"), value: "Jobs" },
             { label: t("article.news"), value: "Post" },
         ].map(preselectedOptions)
     );


### PR DESCRIPTION
… typename of articles

The option was filtering for "job" instead of "jobs" which was the actual typename of the articles which was "jobs"